### PR TITLE
Expose `FSEvents` and `getInfo`.

### DIFF
--- a/fsevents.js
+++ b/fsevents.js
@@ -2,68 +2,72 @@
 ** © 2013 by Philipp Dunkel <p.dunkel@me.com>. Licensed under MIT License.
 */
 
+var fs = require('fs');
 var util = require('util');
-var events = require('events');
+var EventEmitter = require('events').EventEmitter;
 var binding;
 try {
   binding = require('./build/Release/fswatch');
 } catch(ex) {
   binding = require('./build/Debug/fswatch');
 }
-
-var Fs = require('fs');
-
-module.exports = function(path) {
-  var fsevents = new FSEvents(path);
-  fsevents.on('fsevent', function(path, flags, id) {
-    var info = {
-      event:'unknown',
-      id:id,
-      path: path,
-      type: fileType(flags),
-      changes: fileChanges(flags),
-    };
-    if (FSEvents.kFSEventStreamEventFlagItemCreated & flags) {
-      info.event = 'created';
-    } else if (FSEvents.kFSEventStreamEventFlagItemRemoved & flags) {
-      info.event = 'deleted';
-    } else if (FSEvents.kFSEventStreamEventFlagItemRenamed & flags) {
-      info.event = 'moved';
-    } else if (FSEvents.kFSEventStreamEventFlagItemModified & flags) {
-      info.event = 'modified';
-    }
-
-    if (info.event == 'moved') {
-      Fs.stat(info.path, function(err, stat) {
-      if (err || !stat) {
-        info.event = 'moved-out';
-      } else {
-        info.event = 'moved-in';
-      }
-      fsevents.emit('change', path, info);
-      fsevents.emit(info.event, path, info);
-    });
-    } else {
-      fsevents.emit('change', path, info);
-      if (info.event !== 'unknown') fsevents.emit(info.event, path, info);
-    }
-  });
-  return fsevents;
-};
 var FSEvents = binding.FSEvents;
-util.inherits(FSEvents, events.EventEmitter);
+util.inherits(FSEvents, EventEmitter);
 
-function fileType(flags) {
+function getFileType(flags) {
   if (FSEvents.kFSEventStreamEventFlagItemIsFile & flags) return 'file';
   if (FSEvents.kFSEventStreamEventFlagItemIsDir & flags) return 'directory';
   if (FSEvents.kFSEventStreamEventFlagItemIsSymlink & flags) return 'symlink';
 }
 
-function fileChanges(flags) {
-  var res = {};
-  res.inode = !!(FSEvents.kFSEventStreamEventFlagItemInodeMetaMod & flags);
-  res.finder = !!(FSEvents.kFSEventStreamEventFlagItemFinderInfoMod & flags);
-  res.access = !!(FSEvents.kFSEventStreamEventFlagItemChangeOwner & flags);
-  res.xattrs = !!(FSEvents.kFSEventStreamEventFlagItemXattrMod & flags);
-  return res;
+function getEventType(flags) {
+  if (FSEvents.kFSEventStreamEventFlagItemRemoved & flags) return 'deleted';
+  if (FSEvents.kFSEventStreamEventFlagItemCreated & flags) return 'created'
+  if (FSEvents.kFSEventStreamEventFlagItemRenamed & flags) return 'moved';
+  if (FSEvents.kFSEventStreamEventFlagItemModified & flags) return 'modified';
+  return 'unknown';
 }
+
+function getFileChanges(flags) {
+  return {
+    inode: !!(FSEvents.kFSEventStreamEventFlagItemInodeMetaMod & flags),
+    finder: !!(FSEvents.kFSEventStreamEventFlagItemFinderInfoMod & flags),
+    access: !!(FSEvents.kFSEventStreamEventFlagItemChangeOwner & flags),
+    xattrs: !!(FSEvents.kFSEventStreamEventFlagItemXattrMod & flags)
+  };
+}
+
+function getInfo(path, flags) {
+  return {
+    path: path,
+    event: getEventType(flags),
+    type: getFileType(flags),
+    changes: getFileChanges(flags),
+  };
+}
+
+function watch(path) {
+  var fsevents = new FSEvents(path);
+
+  fsevents.on('fsevent', function(path, flags, id) {
+    var info = getInfo(path, flags);
+    info.id = id;
+
+    if (info.event == 'moved') {
+      fs.stat(info.path, function(err, stat) {
+        info.event = (err || !stat) ? 'moved-out' : 'moved-in';
+        fsevents.emit('change', path, info);
+        fsevents.emit(info.event, path, info);
+      });
+    } else {
+      fsevents.emit('change', path, info);
+      if (info.event !== 'unknown') fsevents.emit(info.event, path, info);
+    }
+  });
+
+  return fsevents;
+};
+
+module.exports = watch;
+watch.FSEvents = binding.FSEvents;
+watch.getInfo = getInfo;


### PR DESCRIPTION
Useful for custom file watching libraries. @pipobscure ping

Usage:

``` javascript
var fsevents = require('fsevents');
fsevents.FSEvents // Constructor
fsevents.getInfo // => {event, path, type, changes}
```
