### PR TITLE
Build error on Mac OS 10.6.8

### DIFF
--- a/src/constants.cc
+++ b/src/constants.cc
@@ -3,6 +3,46 @@
 ** Licensed under MIT License.
 */
 
+#ifndef kFSEventStreamEventFlagItemRemoved
+#define kFSEventStreamEventFlagItemRemoved 0x00000200
+#endif
+
+#ifndef kFSEventStreamEventFlagItemInodeMetaMod
+#define kFSEventStreamEventFlagItemInodeMetaMod 0x00000400
+#endif
+
+#ifndef kFSEventStreamEventFlagItemRenamed
+#define kFSEventStreamEventFlagItemRenamed 0x00000800
+#endif
+
+#ifndef kFSEventStreamEventFlagItemModified
+#define kFSEventStreamEventFlagItemModified 0x00001000
+#endif
+
+#ifndef kFSEventStreamEventFlagItemFinderInfoMod
+#define kFSEventStreamEventFlagItemFinderInfoMod 0x00002000
+#endif
+
+#ifndef kFSEventStreamEventFlagItemChangeOwner
+#define kFSEventStreamEventFlagItemChangeOwner 0x00004000
+#endif
+
+#ifndef kFSEventStreamEventFlagItemXattrMod
+#define kFSEventStreamEventFlagItemXattrMod 0x00008000
+#endif
+
+#ifndef kFSEventStreamEventFlagItemIsFile
+#define kFSEventStreamEventFlagItemIsFile 0x00010000
+#endif
+
+#ifndef kFSEventStreamEventFlagItemIsDir
+#define kFSEventStreamEventFlagItemIsDir 0x00020000
+#endif
+
+#ifndef kFSEventStreamEventFlagItemIsSymlink
+#define kFSEventStreamEventFlagItemIsSymlink 0x00040000
+#endif
+
 static v8::Handle<v8::Object> Constants() {
   NanScope();
   v8::Handle<v8::Object> object = v8::Object::New();

--- a/src/thread.cc
+++ b/src/thread.cc
@@ -3,6 +3,10 @@
 ** Licensed under MIT License.
 */
 
+#ifndef kFSEventStreamCreateFlagFileEvents
+#define kFSEventStreamCreateFlagFileEvents 0x00000010
+#endif
+
 void FSEvents::threadStart() {
   if (threadloop) return;
   pthread_create(&thread, NULL, &FSEvents::threadRun, this);


### PR DESCRIPTION
There was a similar issue reported but I'm going to post a separate issue because it may be unrelated.

I'm getting an error when I install fsevents@0.2.1 or  fsevents@0.2.0 on my Mac OS 10.6.8 machine. Does it look like I'm missing some tools or is something wrong?

Thanks

> fsevents@0.2.1 install /Users/adriancarolli/workspace/fsevents
> node-gyp rebuild
> 
> CXX(target) Release/obj.target/fse/fsevents.o
> In file included from ../fsevents.cc:86:
> ../src/thread.cc: In static member function ‘static void\* fse::FSEvents::threadRun(void_)’:
> ../src/thread.cc:30: error: ‘kFSEventStreamCreateFlagFileEvents’ was not declared in this scope
> In file included from ../fsevents.cc:87:
> ../src/constants.cc: In function ‘v8::Handlev8::Object Constants()’:
> ../src/constants.cc:19: error: ‘kFSEventStreamEventFlagItemRemoved’ was not declared in this scope
> ../src/constants.cc:20: error: ‘kFSEventStreamEventFlagItemInodeMetaMod’ was not declared in this scope
> ../src/constants.cc:21: error: ‘kFSEventStreamEventFlagItemRenamed’ was not declared in this scope
> ../src/constants.cc:22: error: ‘kFSEventStreamEventFlagItemModified’ was not declared in this scope
> ../src/constants.cc:23: error: ‘kFSEventStreamEventFlagItemFinderInfoMod’ was not declared in this scope
> ../src/constants.cc:24: error: ‘kFSEventStreamEventFlagItemChangeOwner’ was not declared in this scope
> ../src/constants.cc:25: error: ‘kFSEventStreamEventFlagItemXattrMod’ was not declared in this scope
> ../src/constants.cc:26: error: ‘kFSEventStreamEventFlagItemIsFile’ was not declared in this scope
> ../src/constants.cc:27: error: ‘kFSEventStreamEventFlagItemIsDir’ was not declared in this scope
> ../src/constants.cc:28: error: ‘kFSEventStreamEventFlagItemIsSymlink’ was not declared in this scope
> make: *_\* [Release/obj.target/fse/fsevents.o] Error 1
> gyp ERR! build error 
> gyp ERR! stack Error: `make` failed with exit code: 2
> gyp ERR! stack     at ChildProcess.onExit (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:267:23)
> gyp ERR! stack     at ChildProcess.EventEmitter.emit (events.js:98:17)
> gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:797:12)
> gyp ERR! System Darwin 10.8.0
> gyp ERR! command "node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
> gyp ERR! cwd /Users/adriancarolli/workspace/fsevents
> gyp ERR! node -v v0.10.26
> gyp ERR! node-gyp -v v0.12.2
> gyp ERR! not ok 
