### PR TITLE
Require nan ~1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Native Access to Mac OS-X FSEvents",
   "main": "fsevents.js",
   "dependencies": {
-    "nan": "~1.2.0"
+    "nan": "~1.3.0"
   },
   "os": [
     "darwin"


### PR DESCRIPTION
There's a nasty bug in nan 1.2.0 (something like `Assertion failed: (val->IsString()), function _NanGetExternalParts, file ../node_modules/nan/nan.h, line 2100.`) so that would be awesome if you could update this dependency!

Thanks!
