### PR TITLE
don't crash 'npm rebuild' on non mac platforms

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,14 +1,21 @@
 {
-  "targets": [{
-    "target_name": "fse",
-    "sources": ["fsevents.cc"],
-    "xcode_settings": {
-      "OTHER_LDFLAGS": [
-        "-framework CoreFoundation -framework CoreServices"
-      ]
-    },
-    "include_dirs": [
-      "<!(node -e \"require('nan')\")"
-    ]
-  }]
+  "targets": [
+    { "target_name": "" }
+  ],
+  "conditions": [
+    ['OS=="mac"', {
+      "targets": [{
+        "target_name": "fse",
+        "sources": ["fsevents.cc"],
+        "xcode_settings": {
+          "OTHER_LDFLAGS": [
+            "-framework CoreFoundation -framework CoreServices"
+          ]
+        },
+        "include_dirs": [
+          "<!(node -e \"require('nan')\")"
+        ]
+      }]
+    }]
+  ] 
 }


### PR DESCRIPTION
npm does a bad job at handling platform specific dependencies. with this patch one can run 'npm rebuild' on a non mac platform with fsevents being present in node_modules.
