### PR TITLE
Set the correct NAPI Version now that this has come out of Experimental

### DIFF
--- a/src/fsevents.c
+++ b/src/fsevents.c
@@ -4,8 +4,8 @@
 */
 
 #include <assert.h>
-#define NAPI_VERSION 3
-#define NAPI_EXPERIMENTAL
+
+#define NAPI_VERSION 4
 #include <node_api.h>
 
 #include "rawfsevents.h"


### PR DESCRIPTION
Resolves #259 the problem is simply that node has brought this out of experiemental so that

```CPP
#define NAPI_VERSION 3
#define NAPI_EXPERIMENTAL
#include <node_api.h>
```

no longer works and has to become

```CPP
#define NAPI_VERSION 4
#include <node_api.h>
```
