### PR TITLE
Address Security Issue via node-pre-gyp/tar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 node_modules/
 lib/
 package-lock.json
+.vscode/

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 test/
 build/
 lib/binding/
+.vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ env:
     - NODE_VERSION="v8"
     - NODE_VERSION="v7"
     - NODE_VERSION="v6"
-    - NODE_VERSION="v5"
-    - NODE_VERSION="v4"
 
 before_install:
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "fsevents",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Native Access to Mac OS-X FSEvents",
   "main": "fsevents.js",
   "dependencies": {
     "nan": "^2.12.1",
-    "node-pre-gyp": "^0.10.0"
+    "node-pre-gyp": "^0.12.0"
   },
   "os": [
     "darwin"
@@ -16,7 +16,7 @@
   "scripts": {
     "install": "node install",
     "prepublish": "if [ $(npm -v | head -c 1) -lt 3 ]; then exit 1; fi && npm dedupe",
-    "test": "tap ./test",
+    "test": "node ./test/fsevents.js && node ./test/function.js 2> /dev/null",
     "node-pre-gyp": "node-pre-gyp"
   },
   "binary": {
@@ -42,8 +42,5 @@
   "bundledDependencies": [
     "node-pre-gyp"
   ],
-  "homepage": "https://github.com/strongloop/fsevents",
-  "devDependencies": {
-    "tap": "^12.1.1"
-  }
+  "homepage": "https://github.com/strongloop/fsevents"
 }

--- a/test/fsevents.js
+++ b/test/fsevents.js
@@ -6,7 +6,7 @@
 /* jshint node:true */
 'use strict';
 
-var test = require('tap').test;
+var test = require('./utils/run').test;
 
 test('checking main module', function(t) {
   var mod = load('../');

--- a/test/function.js
+++ b/test/function.js
@@ -8,7 +8,7 @@
 
 var fs = require('fs');
 var path = require('path');
-var test = require('tap').test;
+var test = require('./utils/run').test;
 
 test('functionality testing', function(t) {
   try {

--- a/test/utils/run.js
+++ b/test/utils/run.js
@@ -1,0 +1,39 @@
+
+var assert = require('assert');
+var EventEmitter = require('events').EventEmitter; 
+exports.test = test;
+function test(name, fn) {
+  console.log('TAP version 13');
+  var started = false;
+  var planned = -1;
+  var count = 0;
+  var timeout = null;
+  var tst = new EventEmitter();
+  tst.plan = function (cnt) { planned = cnt; };
+  tst.ok = function (cond, msg) {
+    if (!started) {
+      console.log('1..' + (planned > 0 ? planned : 'N'));
+      started = true;
+    }
+    if (timeout) clearTimeout(timeout);
+    count++;
+    if (cond) {
+      console.log('ok ' + count + ' ' + msg);
+    } else {
+      console.log('not ok ' + count + ' ' + msg);
+    }
+    planned--;
+    if (!planned) {
+      tst.emit('end');
+    } else {
+      timeout = setTimeout(function () {
+        process.exit(1);
+      }, 5000);
+    }
+  };
+  tst.end = function () {
+    if (timeout) clearTimeout(timeout);
+    tst.emit('end');
+  };
+  fn(tst);
+}


### PR DESCRIPTION
This updates the node-pre-gyp dependency and removed the tap devDependency in favour of a very simple test-runner.

Tap used to be OK, but it has since taken on dependencies on everything and the kitchen sink. `npm audit` shows a security issue with a transitive dependency, which is why I decided to finally get rid of tap here too.