### PR TITLE
Add v8 to travis & adapt test-harness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ before_install:
   - source ~/.nvm/nvm.sh
   - nvm install v8
   - nvm install v10
-  - nvm install v11
+  - nvm install v12
 
 install:
-  - nvm use v11
+  - nvm use v12
   - npm install
 
 script:
@@ -18,5 +18,5 @@ script:
   - npm test
   - nvm use v10
   - npm test
-  - nvm use v11
+  - nvm use v12
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ before_install:
   - export PATH=./node_modules/.bin/:$PATH
   - rm -rf ~/.nvm && git clone --depth 1 https://github.com/creationix/nvm.git ~/.nvm
   - source ~/.nvm/nvm.sh
+  - nvm install v8
   - nvm install v10
   - nvm install v11
 
@@ -13,6 +14,8 @@ install:
   - npm install
 
 script:
+  - nvm use v8
+  - npm test
   - nvm use v10
   - npm test
   - nvm use v11

--- a/test/utils/fs.js
+++ b/test/utils/fs.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const utils = require('util');
 const path = require('path');
 
 exports.rmrf = async (file) => {
@@ -26,14 +27,15 @@ exports.rm = async (file, stat) => {
   });
 };
 exports.readdir = async (dir) => {
-  const files = await fs.promises.readdir(dir);
+  const files = await utils.promisify(fs.readdir)(dir);
   return files.map((child) => path.join(file, child));
 };
-exports.stat = fs.promises.stat;
-exports.mkdir = fs.promises.mkdir;
-exports.write = fs.promises.writeFile;
-exports.read = fs.promises.readFile;
-exports.chmod = fs.promises.chmod
+exports.stat = utils.promisify(fs.stat);
+exports.mkdir = utils.promisify(fs.mkdir);
+exports.write = utils.promisify(fs.writeFile);
+exports.read = utils.promisify(fs.readFile);
+exports.chmod = utils.promisify(fs.chmod);
+exports.rename = utils.promisify(fs.rename);
 exports.touch = async (file) => {
   try {
     await exports.stat(file);
@@ -48,4 +50,4 @@ exports.touch = async (file) => {
     });
   });
 };
-exports.rename = fs.promises.rename;
+


### PR DESCRIPTION
Time to 🎉 !!!

Node v8.16.0 is out, so we can add v8 to travis for future tests. In the meantime, up until now the fact that `fsevents` should work with v8.16 was theoretical. I've just tested the v11 pre-built binary against node v8.16.0 and it worked fine!!!