### PR TITLE
Support Persistent Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,14 @@ npm install fsevents
 
 ```js
 const fsevents = require('fsevents');
-const stop = fsevents.watch(__dirname, (path, flags, id) => {
+const stop = fsevents.watch(__dirname [,since],(path, flags, id) => {
   const info = fsevents.getInfo(path, flags, id);
 }); // To start observation
 stop(); // To end observation
 ```
+
+Optional second parameter `since` which can be 0 (the default), meaning to return any changes from now going
+forward. Or a previous event `id`, see below.
 
 The callback passed as the second parameter to `.watch` get's called whenever the operating system detects a
 a change in the file system. It takes three arguments:

--- a/fsevents.js
+++ b/fsevents.js
@@ -13,11 +13,19 @@ if (process.platform !== 'darwin') {
 const Native = require('./fsevents.node');
 const con = Native.constants;
 
-function watch(path, handler) {
-  if ('string' !== typeof path) throw new TypeError(`argument 1 must be a string and not a ${typeof path}`);
-  if ('function' !== typeof handler) throw new TypeError(`argument 2 must be a function and not a ${typeof handler}`);
+function watch(path, since, handler) {
+  let argc = 3;
+  if ('function' === typeof since && handler === undefined) {
+    handler = since;
+    since = 0;
+    argc = 2
+  }
 
-  let instance = Native.start(path, handler);
+  if ('string' !== typeof path) throw new TypeError(`argument 1 must be a string and not a ${typeof path}`);
+  if ('number' !== typeof since) throw new TypeError(`argument 2 must be a number and not a ${typeof since}`)
+  if ('function' !== typeof handler) throw new TypeError(`argument ${argc} must be a function and not a ${typeof handler}`);
+
+  let instance = Native.start(path, since, handler);
   if (!instance) throw new Error(`could not watch: ${path}`);
   return () => {
     const result = instance ? Promise.resolve(instance).then(Native.stop) : null;

--- a/src/rawfsevents.h
+++ b/src/rawfsevents.h
@@ -17,7 +17,7 @@ typedef struct fse_watcher_s* fse_watcher_t;
 void fse_init();
 fse_watcher_t fse_alloc();
 void fse_free(fse_watcher_t watcherp);
-void fse_watch(const char *path, fse_event_handler_t handler, void *context, fse_thread_hook_t hookstart, fse_thread_hook_t hookend, fse_watcher_t watcher_p);
+void fse_watch(const char *path, int64_t since, fse_event_handler_t handler, void *context, fse_thread_hook_t hookstart, fse_thread_hook_t hookend, fse_watcher_t watcher_p);
 void fse_unwatch(fse_watcher_t watcher);
 void *fse_context_of(fse_watcher_t watcher);
 #endif

--- a/test/01_native.js
+++ b/test/01_native.js
@@ -9,7 +9,7 @@ const DIR = fs.realpathSync(process.argv[2]);
 
 run(async () => {
   const events = [];
-  const listener = native.start(DIR, (...args) => events.push(args));
+  const listener = native.start(DIR, 0, (...args) => events.push(args));
 
   await touch(path.join(DIR, 'created'));
   await sleep(250);

--- a/test/01_native.js
+++ b/test/01_native.js
@@ -1,10 +1,11 @@
 const native = require('../fsevents.node');
 const { rm, touch, rename } = require('./utils/fs.js');
 const { run, sleep } = require('./utils/misc.js');
+const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
 
-const DIR = process.argv[2];
+const DIR = fs.realpathSync(process.argv[2]);
 
 run(async () => {
   const events = [];

--- a/test/02_interleaved.js
+++ b/test/02_interleaved.js
@@ -1,10 +1,11 @@
 const native = require('../fsevents.node');
 const { mkdir, rm, touch, rename } = require('./utils/fs.js');
 const { run, sleep } = require('./utils/misc.js');
+const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
 
-const DIR = process.argv[2];
+const DIR = fs.realpathSync(process.argv[2]);
 
 run(async () => {
   await mkdir(`${DIR}/A`);

--- a/test/02_interleaved.js
+++ b/test/02_interleaved.js
@@ -13,11 +13,11 @@ run(async () => {
   await sleep(100);
   const events = [];
 
-  const listenerA = native.start(`${DIR}/A`, (...args) => events.push(args));
+  const listenerA = native.start(`${DIR}/A`, 0, (...args) => events.push(args));
 
   await touch(path.join(`${DIR}/A`, 'created'));
   await sleep(500);
-  const listenerB = native.start(`${DIR}/B`, (...args) => events.push(args));
+  const listenerB = native.start(`${DIR}/B`, 0, (...args) => events.push(args));
   await sleep(500);
   native.stop(listenerA);
   await rename(path.join(`${DIR}/A`, 'created'), path.join(`${DIR}/B`, 'renamed'));

--- a/test/03_simple.js
+++ b/test/03_simple.js
@@ -9,11 +9,12 @@
 const { rm, touch, rename } = require('./utils/fs.js');
 const { sleep, capture, run } = require('./utils/misc.js');
 
+const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
 const fsevents = require('../fsevents');
 
-const DIR = process.argv[2];
+const DIR = fs.realpathSync(process.argv[2]);
 
 run(async ()=>{
   const events = capture();

--- a/test/03_waiting.js
+++ b/test/03_waiting.js
@@ -6,13 +6,14 @@
 /* jshint node:true */
 'use strict';
 
+const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
 const fsevents = require('../fsevents');
 const { run, sleep } = require('./utils/misc.js');
 const { touch } = require('./utils/fs.js');
 
-const DIR = process.argv[2];
+const DIR = fs.realpathSync(process.argv[2]);
 
 run(async ()=>{
   const events = [];

--- a/test/04_emoji.js
+++ b/test/04_emoji.js
@@ -9,11 +9,12 @@
 const { rm, touch, rename } = require('./utils/fs.js');
 const { sleep, capture, run } = require('./utils/misc.js');
 
+const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
 const fsevents = require('../fsevents');
 
-const DIR = process.argv[2];
+const DIR = fs.realpathSync(process.argv[2]);
 
 run(async ()=>{
   const events = capture();


### PR DESCRIPTION
c.f. https://developer.apple.com/library/archive/documentation/Darwin/Conceptual/FSEvents_ProgGuide/UsingtheFSEventsFramework/UsingtheFSEventsFramework.html#//apple_ref/doc/uid/TP40005289-CH4-SW10

I could be persuaded to make the new optional second argument to `watch()` an object with `since` as it first (and for now only) option, if this module ever wants to add more (like being able to differentiate between per-device events and per-host events e.g., but for simplicity’s sake, I’ve kept it simple for now.
