### PR TITLE
Fix random thread hanging due to incorrect pthread_cond_wait usage

### DIFF
--- a/src/rawfsevents.c
+++ b/src/rawfsevents.c
@@ -108,8 +108,10 @@ void fse_watch(const char *path, fse_event_handler_t handler, void *context, fse
   pthread_mutex_lock(&fsevents.lock);
   if (!fsevents.loop) {
     pthread_create(&fsevents.thread, NULL, fse_run_loop, NULL);
+    while(!fsevents.loop) {
+      pthread_cond_wait(&fsevents.init, &fsevents.lock);
+    }
     pthread_mutex_unlock(&fsevents.lock);
-    pthread_cond_wait(&fsevents.init, &fsevents.lock);
   }
 
   strncpy(watcher->path, path, PATH_MAX);

--- a/src/rawfsevents.c
+++ b/src/rawfsevents.c
@@ -108,7 +108,7 @@ void fse_watch(const char *path, fse_event_handler_t handler, void *context, fse
   pthread_mutex_lock(&fsevents.lock);
   if (!fsevents.loop) {
     pthread_create(&fsevents.thread, NULL, fse_run_loop, NULL);
-    while(!fsevents.loop) {
+    while (!fsevents.loop) {
       pthread_cond_wait(&fsevents.init, &fsevents.lock);
     }
     pthread_mutex_unlock(&fsevents.lock);


### PR DESCRIPTION
From the pthread docs: https://linux.die.net/man/3/pthread_cond_wait

> The pthread_cond_timedwait() and pthread_cond_wait() functions shall block on a condition variable. They shall be called with mutex locked by the calling thread or undefined behavior results.

That's why I moved unlock after `pthread_cond_wait`.

Also,

> It is important to note that when pthread_cond_wait() and pthread_cond_timedwait() return without error, the associated predicate may still be false.

That's why I added while loop to check for condition.

This was causing the following issue in Gatsby on OSX: https://github.com/gatsbyjs/gatsby/issues/17131

Due to strange race condition (most likely due to TurboBoost) `pthread_cond_signal` https://github.com/fsevents/fsevents/blob/d5cc566e83d74e5c8d7162773ee1a1dad7cfa0ca/src/rawfsevents.c#L44 was sometimes fired before `pthread_cond_wait`. In such case the thread was not able to wake up and got stuck. Users reported that resizing terminal fixes the issue which was really strange but it can be explained. Resizing terminal sends a `SIGWINCH` which wakes up the thread and code after `pthread_cond_wait` gets executed (we need while loop here).


Thanks for helping with debugging to @ivangoncharov and @knidarkness