### PR TITLE
feat: add typescript definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The `FsEventsInfo` has the following shape:
 
 ```js
 /**
- * @typedef {'created'|'modified'|'deleted'|'moved'|'root-changed'|'unknown'} FsEventsEvent
+ * @typedef {'created'|'modified'|'deleted'|'moved'|'root-changed'|'cloned'|'unknown'} FsEventsEvent
  * @typedef {'file'|'directory'|'symlink'} FsEventsType
  */
 {

--- a/fsevents.d.ts
+++ b/fsevents.d.ts
@@ -1,0 +1,55 @@
+declare type Event =
+    | 'created'
+    | 'cloned'
+    | 'modified'
+    | 'deleted'
+    | 'moved'
+    | 'root-changed'
+    | 'unknown';
+declare type Type = 'file' | 'directory' | 'symlink';
+declare type FileChanges = {
+    inode: boolean;
+    finder: boolean;
+    access: boolean;
+    xattrs: boolean;
+};
+declare type Info = {
+    event: Event;
+    path: string;
+    type: Type;
+    changes: FileChanges;
+    flags: number;
+};
+declare type WatchHandler = (path: string, flags: number, id: string) => void;
+export declare function watch(
+    path: string,
+    handler: WatchHandler,
+): () => Promise<void> | null;
+export declare function getInfo(path: string, flags: number): Info;
+export declare const constants: {
+    None: 0x00000000;
+    MustScanSubDirs: 0x00000001;
+    UserDropped: 0x00000002;
+    KernelDropped: 0x00000004;
+    EventIdsWrapped: 0x00000008;
+    HistoryDone: 0x00000010;
+    RootChanged: 0x00000020;
+    Mount: 0x00000040;
+    Unmount: 0x00000080;
+    ItemCreated: 0x00000100;
+    ItemRemoved: 0x00000200;
+    ItemInodeMetaMod: 0x00000400;
+    ItemRenamed: 0x00000800;
+    ItemModified: 0x00001000;
+    ItemFinderInfoMod: 0x00002000;
+    ItemChangeOwner: 0x00004000;
+    ItemXattrMod: 0x00008000;
+    ItemIsFile: 0x00010000;
+    ItemIsDir: 0x00020000;
+    ItemIsSymlink: 0x00040000;
+    ItemIsHardlink: 0x00100000;
+    ItemIsLastHardlink: 0x00200000;
+    OwnEvent: 0x00080000;
+    ItemCloned: 0x00400000;
+};
+export {}

--- a/package.json
+++ b/package.json
@@ -3,10 +3,15 @@
   "version": "2.1.1",
   "description": "Native Access to MacOS FSEvents",
   "main": "fsevents.js",
+  "types": "fsevents.d.ts",
   "os": [
     "darwin"
   ],
-  "files": ["fsevents.js", "fsevents.node"],
+  "files": [
+    "fsevents.d.ts",
+    "fsevents.js",
+    "fsevents.node"
+  ],
   "engines": {
     "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
   },


### PR DESCRIPTION
The v2 API is so simplified I think it shouldn't be a huge maintenance burden to keep the definition in this repo.

Types are based on the types in the README, plus the missing `cloned` event from #286. Constants were copied from the header file.

I'm unsure about the return type from `watch`. I based it on https://github.com/fsevents/fsevents/blob/e468f15134a1d19943f7c5d1d8d62ce1e60401c2/fsevents.js#L26-L30, but I don't know what the promise resolves to? Also, should it always return a `Promise` regardless of `instance === null` or not? Happy to tweak that part of the code.

EDIT: I've opened up a separate PR with the change to always return a Promise, and you can choose to accept that or not. I can tweak the type in this PR based on that conclusion: #296