### PR TITLE
feat: always return a promise from the stopper function

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ stop(); // To end observation
 The callback passed as the second parameter to `.watch` get's called whenever the operating system detects a
 a change in the file system. It takes three arguments:
 
-###### `fsevents.watch(dirname: string, (path: string, flags: number, id: string) => void): () => Promise<null>`
+###### `fsevents.watch(dirname: string, (path: string, flags: number, id: string) => void): () => Promise<undefined>`
 
  * `path: string` - the item in the filesystem that have been changed
  * `flags: number` - a numeric value describing what the change was

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ stop(); // To end observation
 The callback passed as the second parameter to `.watch` get's called whenever the operating system detects a
 a change in the file system. It takes three arguments:
 
-###### `fsevents.watch(dirname: string, (path: string, flags: number, id: string) => void): Function`
+###### `fsevents.watch(dirname: string, (path: string, flags: number, id: string) => void): () => Promise<null>`
 
  * `path: string` - the item in the filesystem that have been changed
  * `flags: number` - a numeric value describing what the change was
  * `id: string` - an unique-id identifying this specific event
- 
- Returns closer callback.
+
+ Returns closer callback which when called returns a Promise resolving when the watcher process has been shut down.
 
 ###### `fsevents.getInfo(path: string, flags: number, id: string): FsEventInfo`
 
@@ -47,7 +47,7 @@ The `FsEventsInfo` has the following shape:
 
 ```js
 /**
- * @typedef {'created'|'modified'|'deleted'|'moved'|'root-changed'|'unknown'} FsEventsEvent
+ * @typedef {'created'|'modified'|'deleted'|'moved'|'root-changed'|'cloned'|'unknown'} FsEventsEvent
  * @typedef {'file'|'directory'|'symlink'} FsEventsType
  */
 {

--- a/fsevents.js
+++ b/fsevents.js
@@ -24,7 +24,9 @@ function watch(path, handler) {
   let instance = Native.start(path, handler);
   if (!instance) throw new Error(`could not watch: ${path}`);
   return () => {
-    const result = instance ? Promise.resolve(instance).then(Native.stop) : null;
+    const result = instance
+        ? Promise.resolve(instance).then(Native.stop).then(() => null)
+        : Promise.resolve(null);
     instance = null;
     return result;
   };

--- a/fsevents.js
+++ b/fsevents.js
@@ -25,9 +25,9 @@ function watch(path, handler) {
   if (!instance) throw new Error(`could not watch: ${path}`);
   return () => {
     const result = instance
-        ? Promise.resolve(instance).then(Native.stop).then(() => null)
-        : Promise.resolve(null);
-    instance = null;
+        ? Promise.resolve(instance).then(Native.stop).then(() => undefined)
+        : Promise.resolve(undefined);
+    instance = undefined;
     return result;
   };
 }


### PR DESCRIPTION
As mentioned in #295, the return value of the stopper function seems inconsistent. This makes it always return `Promise<null>` regardless of when it's called.

An open question is - does `Native.stop` resolve with a value? I tested locally and it always resolved to `undefined`, so I'm thinking just resolving to `null` is fine. But I don't know C, so it might resolve to something else in some cases?

(I've also updated the readme with the new event from #286).