### PR TITLE
Remove node-pre-gyp from bundled dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,5 @@
   "bugs": {
     "url": "https://github.com/strongloop/fsevents/issues"
   },
-  "bundledDependencies": [
-    "node-pre-gyp"
-  ],
   "homepage": "https://github.com/strongloop/fsevents"
 }


### PR DESCRIPTION
It seems like the intent was to remove `node-pre-gyp` from the `1.x` branch, but it's still present in `bundledDependencies`. Remove from there as well so dependencies that can't yet upgrade from `1.x` stop getting security audit failures.