### PR TITLE
Bump license years

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
-If you are NOT on OS X and have come here to file an issue about compatibility problems, 
-please stop and go to #115 for your answer.
+**If you are NOT on macOS and have come here to file an issue about compatibility problems, 
+please stop and go to #115 for your answer.**
 
 You can look through many other similar closed issues as well if you're interested:
 https://github.com/strongloop/fsevents/search?utf8=%E2%9C%93&q=%22notsup%22+OR+%22EBADPLATFORM%22&type=Issues.

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 -----------
 
-Copyright (C) 2010-2019 by Philipp Dunkel, Ben Noordhuis, Elan Shankar, Paul Miller
+Copyright (C) 2010-2020 by Philipp Dunkel, Ben Noordhuis, Elan Shankar, Paul Miller
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -72,6 +72,6 @@ The `FsEventsInfo` has the following shape:
 
 ## License
 
-The MIT License Copyright (C) 2010-2019 by Philipp Dunkel, Ben Noordhuis, Elan Shankar, Paul Miller — see LICENSE file.
+The MIT License Copyright (C) 2010-2020 by Philipp Dunkel, Ben Noordhuis, Elan Shankar, Paul Miller — see LICENSE file.
 
 Visit our [GitHub page](https://github.com/fsevents/fsevents) and [NPM Page](https://npmjs.org/package/fsevents)

--- a/fsevents.js
+++ b/fsevents.js
@@ -1,5 +1,5 @@
 /*
- ** © 2018 by Philipp Dunkel, Ben Noordhuis, Elan Shankar, Paul Miller
+ ** © 2020 by Philipp Dunkel, Ben Noordhuis, Elan Shankar, Paul Miller
  ** Licensed under MIT License.
  */
 

--- a/src/fsevents.c
+++ b/src/fsevents.c
@@ -1,5 +1,5 @@
 /*
-** © 2018 by Philipp Dunkel, Ben Noordhuis, Elan Shankar
+** © 2020 by Philipp Dunkel, Ben Noordhuis, Elan Shankar
 ** Licensed under MIT License.
 */
 

--- a/test/02_structure.js
+++ b/test/02_structure.js
@@ -1,5 +1,5 @@
 /*
- ** © 2018 by Philipp Dunkel, Ben Noordhuis, Elan Shankar
+ ** © 2020 by Philipp Dunkel, Ben Noordhuis, Elan Shankar
  ** Licensed under MIT License.
  */
 

--- a/test/03_simple.js
+++ b/test/03_simple.js
@@ -1,5 +1,5 @@
 /*
- ** © 2018 by Philipp Dunkel, Ben Noordhuis, Elan Shankar
+ ** © 2020 by Philipp Dunkel, Ben Noordhuis, Elan Shankar
  ** Licensed under MIT License.
  */
 

--- a/test/03_waiting.js
+++ b/test/03_waiting.js
@@ -1,5 +1,5 @@
 /*
- ** © 2018 by Philipp Dunkel, Ben Noordhuis, Elan Shankar
+ ** © 2020 by Philipp Dunkel, Ben Noordhuis, Elan Shankar
  ** Licensed under MIT License.
  */
 

--- a/test/04_emoji.js
+++ b/test/04_emoji.js
@@ -1,12 +1,12 @@
 /*
- ** © 2018 by Philipp Dunkel, Ben Noordhuis, Elan Shankar
+ ** © 2020 by Philipp Dunkel, Ben Noordhuis, Elan Shankar
  ** Licensed under MIT License.
  */
 
 /* jshint node:true */
 'use strict';
 
-const { rm, touch, rename } = require('./utils/fs.js');
+const { rm, touch } = require('./utils/fs.js');
 const { sleep, capture, run } = require('./utils/misc.js');
 
 const path = require('path');


### PR DESCRIPTION
Signed-off-by: Reece Dunham <me@rdil.rocks>

Also includes a bit of extra code cleanup, e.g. removing an unused import and changing OS X -> macOS (was renamed a few years ago)