### PR TITLE
Only build fsevents on macOS

### DIFF
--- a/install.js
+++ b/install.js
@@ -1,0 +1,13 @@
+const { spawn } = require('child_process');
+
+const rebuildIfDarwin = () => {
+  if (process.platform !== 'darwin') {
+    console.log();
+    console.log(`Skipping 'fsevents' build as platform ${process.platform} is not supported`);
+    process.exit(0);
+  } else {
+    spawn('node-gyp', ['rebuild'], { stdio: 'inherit' });
+  }
+};
+
+rebuildIfDarwin();

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "node": ">= 4.0"
   },
   "scripts": {
-    "test": "node ./test/fsevents.js && node ./test/function.js 2> /dev/null"
+    "test": "node ./test/fsevents.js && node ./test/function.js 2> /dev/null",
+    "install": "node install.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #301 

According to the [npm docs](https://docs.npmjs.com/misc/scripts#default-values), if a `binding.gyp` is detected, `npm` will run `node-gyp rebuild` by default unless an `install` script is specified. For some reason, even though `'OS=="mac"'` is specified in the `binding.gyp`, it builds on Windows anyway. This PR adds an `install` script that checks the platform and only runs `node-gyp rebuild` if a macOS environment is detected.