### PR TITLE
Initialize async member

### DIFF
--- a/fsevents.cc
+++ b/fsevents.cc
@@ -54,6 +54,7 @@ using namespace fse;
 
 FSEvents::FSEvents(const char *path)
    : async_resource("fsevents:FSEvents") {
+  memset(&async, 0, sizeof(async));
   CFStringRef dirs[] = { CFStringCreateWithCString(NULL, path, kCFStringEncodingUTF8) };
   paths = CFArrayCreate(NULL, (const void **)&dirs, 1, NULL);
   threadloop = NULL;


### PR DESCRIPTION
Initialize async member otherwise it may happen that in `FSEvents::asyncStart()` the check `async.data == this` is already `true` and as a result `uv_async_init()` is not called.

Refs.: https://github.com/nodejs/node/pull/34776#issuecomment-674314154