### PR TITLE
fix(typings): add return type to `watch` overload

### DIFF
--- a/fsevents.d.ts
+++ b/fsevents.d.ts
@@ -15,7 +15,7 @@ declare type Info = {
 };
 declare type WatchHandler = (path: string, flags: number, id: string) => void;
 export declare function watch(path: string, handler: WatchHandler): () => Promise<void>;
-export declare function watch(path: string, since: number, handler: WatchHandler);
+export declare function watch(path: string, since: number, handler: WatchHandler): () => Promise<void>;
 export declare function getInfo(path: string, flags: number): Info;
 export declare const constants: {
   None: 0x00000000;


### PR DESCRIPTION
Missing from #342 I believe.

![image](https://user-images.githubusercontent.com/1404810/99148621-10d98d00-2689-11eb-9d10-6f3c1806c3be.png)
