### PR TITLE
fix: build universal binary (arm64/apple silicon)

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -2,7 +2,7 @@ name: Node CI
 on: [push, pull_request]
 jobs:
   build:
-    runs-on: macOS-latest
+    runs-on: macOS-11.0
     strategy:
       matrix:
         node-version: [8, 10, 12, 14, 15]
@@ -18,5 +18,10 @@ jobs:
         npm install
         npm run build --if-present
         npm test
+    - name: ensure universal binary (arm64/x86_64)
+      run: |
+        file fsevents.node
+        file fsevents.node | grep -q arm64 || (echo "arm64 binary not built"; exit 1)
+        file fsevents.node | grep -q x86_64 || (echo "x86_64 binary not built"; exit 1)
       env:
         CI: true

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -21,8 +21,8 @@ jobs:
     - name: ensure universal binary (arm64/x86_64)
       run: |
         file fsevents.node
-        file fsevents.node | grep -q arm64 || echo "arm64 binary not built"
-        file fsevents.node | grep -q x86_64 || echo "x86_64 binary not built"
+        file fsevents.node | grep -q arm64 || (echo "arm64 binary not built"; exit 1)
+        file fsevents.node | grep -q x86_64 || (echo "x86_64 binary not built"; exit 1)
     - name: Upload binary
       uses: actions/upload-artifact@v2
       with:
@@ -54,8 +54,8 @@ jobs:
     - name: ensure universal binary (arm64/x86_64)
       run: |
         file fsevents.node
-        file fsevents.node | grep -q arm64 || echo "arm64 binary not built"
-        file fsevents.node | grep -q x86_64 || echo "x86_64 binary not built"
+        file fsevents.node | grep -q arm64 || (echo "arm64 binary not built"; exit 1)
+        file fsevents.node | grep -q x86_64 || (echo "x86_64 binary not built"; exit 1)
     - name: npm test
       run: |
         npm test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -2,7 +2,7 @@ name: Node CI
 on: [push, pull_request]
 jobs:
   build:
-    runs-on: macOS-11.0
+    runs-on: macos-11.0
     strategy:
       matrix:
         node-version: [8, 10, 12, 14, 15]
@@ -24,15 +24,15 @@ jobs:
         file fsevents.node | grep -q arm64 || echo "arm64 binary not built"
         file fsevents.node | grep -q x86_64 || echo "x86_64 binary not built"
     - name: Upload binary
-        uses: actions/upload-artifact@v2
-        with:
-          name: binary
-          path: fsevents.node
+      uses: actions/upload-artifact@v2
+      with:
+        name: binary
+        path: fsevents.node
       env:
         CI: true
   test_macos_10:
     name: 'Test universal binary on macOS 10.15'
-    runs-on: macOS-10.15
+    runs-on: macos-10.15
     needs: build
     strategy:
       matrix:
@@ -48,9 +48,9 @@ jobs:
       run: |
         npm install
     - name: Download universal binary
-        uses: actions/download-artifact@v2
-        with:
-          name: binary
+      uses: actions/download-artifact@v2
+      with:
+        name: binary
     - name: ensure universal binary (arm64/x86_64)
       run: |
         file fsevents.node

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -44,9 +44,9 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: npm install, build, and test
+    - name: npm install
       run: |
-        npm install
+        npm install --ignore-scripts
     - name: Download universal binary
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -21,7 +21,43 @@ jobs:
     - name: ensure universal binary (arm64/x86_64)
       run: |
         file fsevents.node
-        file fsevents.node | grep -q arm64 || (echo "arm64 binary not built"; exit 1)
-        file fsevents.node | grep -q x86_64 || (echo "x86_64 binary not built"; exit 1)
+        file fsevents.node | grep -q arm64 || echo "arm64 binary not built"
+        file fsevents.node | grep -q x86_64 || echo "x86_64 binary not built"
+    - name: Upload binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: binary
+          path: fsevents.node
+      env:
+        CI: true
+  test_macos_10:
+    name: 'Test universal binary on macOS 10.15'
+    runs-on: macOS-10.15
+    needs: build
+    strategy:
+      matrix:
+        node-version: [8, 10, 12, 14, 15]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Node v${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: npm install, build, and test
+      run: |
+        npm install
+    - name: Download universal binary
+        uses: actions/download-artifact@v2
+        with:
+          name: binary
+    - name: ensure universal binary (arm64/x86_64)
+      run: |
+        file fsevents.node
+        file fsevents.node | grep -q arm64 || echo "arm64 binary not built"
+        file fsevents.node | grep -q x86_64 || echo "x86_64 binary not built"
+    - name: npm test
+      run: |
+        npm test
       env:
         CI: true

--- a/binding.gyp
+++ b/binding.gyp
@@ -5,9 +5,15 @@
         "target_name": "fsevents",
         "sources": [ "src/fsevents.c"],
         "xcode_settings": {
+          "OTHER_CFLAGS": [
+            "-arch x86_64",
+            "-arch arm64"
+          ],
           "OTHER_LDFLAGS": [
             "-Wl,-bind_at_load",
-            "-framework CoreFoundation -framework CoreServices"
+            "-framework CoreFoundation -framework CoreServices",
+            "-arch x86_64",
+            "-arch arm64"
           ]
         }
       }, {


### PR DESCRIPTION
Fixes #349 

I was able to verify that this works properly on my M1 and creates an universal binary that contains both an x86_64 slice and an arm64 slice. 

To verify:

```
$ file fsevents.node
fsevents.node: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit bundle x86_64] [arm64:Mach-O 64-bit bundle arm64]
fsevents.node (for architecture x86_64):        Mach-O 64-bit bundle x86_64
fsevents.node (for architecture arm64): Mach-O 64-bit bundle arm64
```

Should check that it continues working properly on x86_64 as well, I don't have an Intel machine any more to test, but I don't see any reason it wouldn't.