### PR TITLE
fix: issue #355

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ on:
     - 'master'
 jobs:
   build:
-    runs-on: macos-11.0
+    runs-on: self-hosted
     strategy:
       matrix:
         node-version: [8, 10, 12, 14, 15]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     - master
 jobs:
   publish:
-    runs-on: macos-11.0
+    runs-on: self-hosted
     steps:
     - name: checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
The `napi_external` that maintains the watch on a file is closured into the *stop* function returned by `fsevents.watch`.
When that `napi_external` is garbage collected, the callback that was passed in is released and becomes uncallable. When it is called depsite this, the `napi_env` that is passed in is `NULL` which is intended by N-API as a signal  that the function is no longer usable. 

I ignored it in the past, because I always retain the stop function. However a test-script like the one provided provokes this. When garbage collection happens, the `napi_external` is cleared. However there may still be events in the pipeline. And that in turn triggers the crash in #355 .

I am now handling the `napi_env` as `NULL` signal properly by just dropping the event. In consequence, if you do not retain the *stop* function event reporting simply stops. And this will happen fairly quickly.

fixes #355 