### PR TITLE
Limit node versions to <= 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "darwin"
   ],
   "engines": {
-    "node": ">= 4.0"
+    "node": ">=4.0 <=12"
   },
   "scripts": {
     "test": "node ./test/fsevents.js && node ./test/function.js 2> /dev/null",


### PR DESCRIPTION
This PR adds a limitation on node versions. It should ensure chokidar@2.x doesn't get accidentally installed in unsupported Node versions. [Reference](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#engines)

After this change, both `yarn install` and `npm install --engine-strict` will refuse to install this package if Node version is 14 or above.


With Node 12:
```
$ nvm use v12 && yarn install
Now using node v12.21.0 (npm v6.14.11)
yarn install v1.22.10
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
...

$ nvm use v12 && npm install --engine-strict
Now using node v12.21.0 (npm v6.14.11)

> fsevents@1.2.13 install /Users/sergio/src/forks/fsevents
> node install.js
...
```

With Node 14:
```
$ nvm use v14 && yarn install
Now using node v14.16.0 (npm v6.14.11)
yarn install v1.22.10
[1/5] 🔍  Validating package.json...
error fsevents@1.2.13: The engine "node" is incompatible with this module. Expected version ">=4.0 <=12". Got "14.16.0"
error Found incompatible module.

$ nvm use v14 && npm install --engine-strict
Now using node v14.16.0 (npm v6.14.11)
npm ERR! code ENOTSUP
npm ERR! notsup Unsupported engine for fsevents@1.2.13: wanted: {"node":">=4.0 <=12"} (current: {"node":"14.16.0","npm":"6.14.11"})
npm ERR! notsup Not compatible with your version of node/npm: fsevents@1.2.13
npm ERR! notsup Not compatible with your version of node/npm: fsevents@1.2.13
npm ERR! notsup Required: {"node":">=4.0 <=12"}
npm ERR! notsup Actual:   {"npm":"6.14.11","node":"14.16.0"}
```

