### PR TITLE
fix: build universal binary (arm64/apple silicon)

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -8,8 +8,15 @@
         "target_name": "fse",
         "sources": ["fsevents.cc"],
         "xcode_settings": {
+          "OTHER_CFLAGS": [
+            "-arch x86_64",
+            "-arch arm64"
+          ],
           "OTHER_LDFLAGS": [
             "-framework CoreFoundation -framework CoreServices"
+            "-framework CoreFoundation -framework CoreServices",
+            "-arch x86_64",
+            "-arch arm64"
           ]
         },
         "include_dirs": [


### PR DESCRIPTION
This ports the commit 579e7d88e7c79dc00d43ef3ef08698469c97f568 from master to the v1.x branch, adding support for Apple M1.