### PR TITLE
support inode on MacOS 10.13+

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,25 +22,25 @@ npm install fsevents
 ```js
 const fsevents = require('fsevents');
 const stop = fsevents.watch(__dirname, (path, flags, id) => {
-  const info = fsevents.getInfo(path, flags, id);
+  const info = fsevents.getInfo(path, flags);
 }); // To start observation
 stop(); // To end observation
 ```
 
 The callback passed as the second parameter to `.watch` get's called whenever the operating system detects a
-a change in the file system. It takes three arguments:
+change in the file system. It takes three arguments:
 
 ###### `fsevents.watch(dirname: string, (path: string, flags: number, id: string) => void): () => Promise<undefined>`
 
- * `path: string` - the item in the filesystem that have been changed
+ * `path: string` - the item in the filesystem that has been changed
  * `flags: number` - a numeric value describing what the change was
  * `id: string` - an unique-id identifying this specific event
 
  Returns closer callback which when called returns a Promise resolving when the watcher process has been shut down.
 
-###### `fsevents.getInfo(path: string, flags: number, id: string): FsEventInfo`
+###### `fsevents.getInfo(path: string, flags: number): FsEventInfo`
 
-The `getInfo` function takes the `path`, `flags` and `id` arguments and converts those parameters into a structure
+The `getInfo` function takes the `path` and `flags` arguments and converts those parameters into a structure
 that is easier to digest to determine what the change was.
 
 The `FsEventsInfo` has the following shape:

--- a/fsevents.d.ts
+++ b/fsevents.d.ts
@@ -13,7 +13,7 @@ declare type Info = {
   changes: FileChanges;
   flags: number;
 };
-declare type WatchHandler = (path: string, flags: number, id: string) => void;
+declare type WatchHandler = (path: string, flags: number, id: string, inode?: number) => void;
 export declare function watch(path: string, handler: WatchHandler): () => Promise<void>;
 export declare function watch(path: string, since: number, handler: WatchHandler): () => Promise<void>;
 export declare function getInfo(path: string, flags: number): Info;

--- a/src/constants.h
+++ b/src/constants.h
@@ -1,6 +1,7 @@
 #ifndef __constants_h
 #define __constants_h
 
+#include "Availability.h"
 #include "CoreFoundation/CoreFoundation.h"
 #include "CoreServices/CoreServices.h"
 
@@ -124,6 +125,10 @@
 
 #ifndef kFSEventStreamCreateFlagFileEvents
 #define kFSEventStreamCreateFlagFileEvents 0x00000010
+#endif
+
+#ifndef kFSEventStreamCreateFlagUseExtendedData
+#define kFSEventStreamCreateFlagUseExtendedData 0x00000040
 #endif
 
 #endif


### PR DESCRIPTION
Support reporting `inode` with event data on MacOS 10.13+.

```js
const fsevents = require('fsevents');
const stop = fsevents.watch(__dirname, (path, flags, id, inode) => {
  ...
});
stop();
```