### PR TITLE
Update README: pass 2 params to getInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ const fsevents = require('fsevents');
 
 // To start observation
 const stop = fsevents.watch(__dirname, (path, flags, id) => {
-  const info = fsevents.getInfo(path, flags, id);
+  const info = fsevents.getInfo(path, flags);
 });
 
 // To end observation


### PR DESCRIPTION
getInfo() accepts two params, not three
https://github.com/fsevents/fsevents/blob/master/fsevents.js#L40