### PR TITLE
Handle MustScanSubDirs for large projects

### DIFF
--- a/fsevents.js
+++ b/fsevents.js
@@ -50,6 +50,7 @@ function getInfo(path, flags) {
 function getFileType(flags) {
   if (events.ItemIsFile & flags) return "file";
   if (events.ItemIsDir & flags) return "directory";
+  if (events.MustScanSubDirs & flags) return "directory"; 
   if (events.ItemIsSymlink & flags) return "symlink";
 }
 function anyIsTrue(obj) {


### PR DESCRIPTION
When you scan a really large folder for file event changes, the client or kernel might not be able to keep up with all the initial 'add' events sent by fsevents.

This happens for me with our humongous vite project that has thousands of files that are sent to firefox. At some point today, chokidar receives undefined as file type when it's actually a rescan request, and fsevents / chokidar attempts to unlink the directory instead of rescanning it, making vite crash after a while instead of finishing processing fsevents.

This might be a fix in the correct direction, but the maintainers here are probably better at evaluating it. With this patch locally, vite no longer stops working for large projects on initial load.