### PR TITLE
Upgrade node-gyp to fix install

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
   },
   "homepage": "https://github.com/fsevents/fsevents",
   "devDependencies": {
-    "node-gyp": "^6.1.0"
+    "node-gyp": "^8.2.0"
   }
 }


### PR DESCRIPTION
I ran into various install issues and deprecations, eventually tracing it to an old version of 
`node-gyp`.  ~~`8.0.0`~~`8.2.0` is the earliest version that fixes the install for me.

M1 MacBook Air, Ventura 13.4.1
