### PR TITLE
Fixes on vue build: Module parse failed: Unexpected character '�' (1:0)

### DIFF
--- a/fsevents.js
+++ b/fsevents.js
@@ -10,7 +10,7 @@ if (process.platform !== "darwin") {
   throw new Error(`Module 'fsevents' is not compatible with platform '${process.platform}'`);
 }
 
-const Native = require("./fsevents.node");
+const Native = window.require("./fsevents.node");
 const events = Native.constants;
 
 function watch(path, since, handler) {


### PR DESCRIPTION
ERROR  Failed to compile with 1 errors                                                                                    10:25:14 AM

 error  in ./node_modules/fsevents/fsevents.node

Module parse failed: Unexpected character '�' (1:0) You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders (Source code omitted for this binary file)