### PR TITLE
Improve header usage

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -1,9 +1,6 @@
 #ifndef __constants_h
 #define __constants_h
 
-#include "CoreFoundation/CoreFoundation.h"
-#include "CoreServices/CoreServices.h"
-
 // constants from https://developer.apple.com/documentation/coreservices/1455361-fseventstreameventflags?language=objc
 #ifndef kFSEventStreamEventFlagNone
 #define kFSEventStreamEventFlagNone 0x00000000

--- a/src/fsevents.c
+++ b/src/fsevents.c
@@ -20,6 +20,9 @@
 #endif
 #endif
 
+#include "CoreFoundation/CFRunLoop.h"
+#include "FSEvents/FSEvents.h"
+
 #include "constants.h"
 #define CONSTANT(name)                                                               \
   do                                                                                 \


### PR DESCRIPTION
The current CF/CS includes pull in too many headers that aren't needed. It's pretty easy to scope them down to what we actually use.