### PR TITLE
Strip node-gyp from package.json before publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,8 @@ jobs:
         file fsevents.node
         file fsevents.node | grep -q arm64 || (echo "arm64 binary not built"; exit 1)
         file fsevents.node | grep -q x86_64 || (echo "x86_64 binary not built"; exit 1)
+    - name: Strip node-gyp from package.json
+      run: yq -iP 'del(.scripts, .devDependencies)' package.json -o json
     - id: publish
       name: npm publish
       uses: JS-DevTools/npm-publish@v1


### PR DESCRIPTION
There's a quirk in Yarn v4 (yarnpkg/berry#3366) that causes `node-gyp` to be injected as a dependency of `fsevents`, despite `fsevents` now shipping with only a prebuilt `fsevents.node` and no source. The `node-gyp` dependency brings in a lot of transitive dependencies in lock files, and lately this is causing a lot of audit noise as some of these dependencies (namely `tar` and `minimatch`) are being hammered with new CVEs.

This quirk in Yarn v4 can be sidestepped if all references to `node-gyp` are stripped from `package.json` before publishing it, which is easy enough to do in the publish workflow.